### PR TITLE
Fix Typo in build-windows.rst

### DIFF
--- a/ja/install/build-windows.rst
+++ b/ja/install/build-windows.rst
@@ -307,7 +307,7 @@ Choreonoidの実行ファイル "choreonoid.exe" がインストール先のbin�
 
 として起動します。（この場合はディレクトリの区切り文字として "/" しか使用できません。）Git Bash端末の場合は、ディレクトリ区切り文字として "/" を用いて ::
 
- c:/choreonoid/bin/choreonoid.ext
+ c:/choreonoid/bin/choreonoid.exe
 
 とします。どちらの場合も、拡張子の ".exe" は省略可能です。インストール先が "c:\\choreonoid" でない場合は、その部分を実際のインストール先に置き換えるようにしてください。
 


### PR DESCRIPTION
Hi,
I found a small typo in the doc and have submitted this PR for a quick fix.

[ソースコードからのビルドとインストール (Windows編) — Choreonoid 開発版 ドキュメント](https://choreonoid.org/ja/manuals/latest/install/build-windows.html)

Change:
from: ".ext"
to: ".exe"
![image](https://github.com/choreonoid/choreonoid-doc/assets/28650189/97c8f71e-ccce-4b07-92cc-8478babbb198)

I hope this helps! Thank you for your great work on this project.